### PR TITLE
Use entity UUID as seed for the random.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ build
 .gradle
 
 # other
+.vscode
+.eclipse
+.factorypath
 eclipse
 run
 runs

--- a/common/src/main/java/com/tristankechlo/random_mob_sizes/mixin/entity/MobMixin.java
+++ b/common/src/main/java/com/tristankechlo/random_mob_sizes/mixin/entity/MobMixin.java
@@ -6,6 +6,7 @@ import com.tristankechlo.random_mob_sizes.mixin_helper.MobMixinAddon;
 import com.tristankechlo.random_mob_sizes.sampler.ScalingSampler;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.entity.*;
@@ -22,12 +23,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /* Adds another EntityDataAccessor to the Mob class to store the scale factor */
 @Mixin(Mob.class)
-public abstract class MobMixin implements MobMixinAddon {
+public abstract class MobMixin extends LivingEntity implements MobMixinAddon {
 
     @Unique
     private boolean scaleLoot$RandomMobSizes = false;
     @Unique
     private boolean scaleExperience$RandomMobSizes = false;
+
+    private MobMixin(){ super(null, null); }
 
     @Override
     public boolean shouldScaleLoot$RandomMobSizes() {
@@ -59,7 +62,7 @@ public abstract class MobMixin implements MobMixinAddon {
         Difficulty difficulty = level.getDifficulty();
         double scaling = 1.0F;
         if (sampler != null) {
-            scaling = sampler.sample(level.getRandom(), level.getDifficulty());
+            scaling = sampler.sample(RandomSource.create(this.getUUID().hashCode()), level.getDifficulty());
 
             if (sampler.shouldScaleHealth(difficulty)) {
                 double healthScaling = sampler.getHealthScaler(difficulty).apply(scaling);


### PR DESCRIPTION
Uses the UUID of the entity as the seed for its random size. (Similarly to EMT/ETF random textures).

The intent is that when combined with [UUID-preserving mods](https://modrinth.com/mod/zombie-uuid-preservation/gallery), entities will keep their size when transformed into another one. (Or at the very least, keep it consistent if the entity types are configured differently.) For example, when villagers get zombified or cured.